### PR TITLE
Arduino側が取りうる状態を列挙型で管理するようにした

### DIFF
--- a/wear/state.h
+++ b/wear/state.h
@@ -1,0 +1,11 @@
+#ifndef __STATE_H__
+#define __STATE_H__
+
+enum class WearableState {
+  Waiting,
+  WaitingWithColor,
+  Charge,
+  Explode,
+};
+
+#endif

--- a/wear/wear.ino
+++ b/wear/wear.ino
@@ -1,6 +1,7 @@
 #include <math.h>
 #include <stdlib.h>
 #include "signal.h"
+#include "state.h"
 
 #define ACCELERO_X 1
 #define ACCELERO_Y 2
@@ -9,12 +10,37 @@
 const int moveVectorThreshold = 750;
 
 LowPath lowPath = LowPath();
+WearableState currentState = WearableState::Waiting;
 
 void setup() {
   Serial.begin(9600);
+  // デバッグ用にChargeにしている。
+  // ある程度コードが完成してきたらここでChargeにしないようにする。
+  currentState = WearableState::Charge;
 }
 
 void loop() {
+  switch(currentState) {
+    case WearableState::Waiting:
+      // 今のところはなにもしない
+      break;
+    case WearableState::WaitingWithColor:
+      // TODO: 色が明滅するようなエフェクトをつける
+      break;
+    case WearableState::Charge:
+      charging_action();
+      break;
+    case WearableState::Explode:
+      // TODO: いい感じの爆発エフェクトをつける
+      // TODO: 評価関数をつくる
+      break;
+    default:
+      // UNREACHABLE
+      break;
+  }
+}
+
+void charging_action() {
   double ax = analogRead(ACCELERO_X) * 5.0/1023.0;
   double ay = analogRead(ACCELERO_Y) * 5.0/1023.0;
   double az = analogRead(ACCELERO_Z) * 5.0/1023.0;


### PR DESCRIPTION
コードの可読性のため `enum class` で状態を管理するようにした。